### PR TITLE
Use lazy reader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   base:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
     working_directory: /go/src/github.com/spatialcurrent/gocat
 jobs:
   pre_deps_golang:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Spatial Current, Inc.
+Copyright (c) 2020 Spatial Current, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See the usage below or the following examples.
 ```shell
 gocat is a super simple utility to concatenate files (local, remote, or on AWS S3) provided as positional arguments.
 Supports stdin (aka "-"), local files (path/to/file or file://path/to/file), remote files (http://path/to/file), or files on AWS S3 (s3://path/to/file).
-Supports the following compression algorithms: bzip2, flate, gzip, none, snappy, zip, zlib
+Supports the following compression algorithms: bzip2, flate, gzip, none, snappy, zip, zlib.
 
 Usage:
   gocat [flags] [-|stdin|FILE|URI]...
@@ -92,7 +92,7 @@ The `make build_cli` script is used to build executables for Linux and Windows. 
 
 **Changing Destination**
 
-The default destination for build artifacts is `go-reader-writer/bin`, but you can change the destination with an environment variable.  For building on a Chromebook consider saving the artifacts in `/usr/local/go/bin`, e.g., `DEST=/usr/local/go/bin make build_cli`
+The default destination for build artifacts is `gocat/bin`, but you can change the destination with an environment variable.  For building on a Chromebook consider saving the artifacts in `/usr/local/go/bin`, e.g., `DEST=/usr/local/go/bin make build_cli`
 
 ## Testing
 

--- a/main.go
+++ b/main.go
@@ -99,6 +99,7 @@ Supports the following compression algorithms: ` + strings.Join(grw.Algorithms, 
 
 			inputReaders := make([]io.Reader, 0)
 			for _, uri := range args {
+				uri := uri
 
 				if uri == "-" {
 					uri = "stdin"


### PR DESCRIPTION
This PR adds support for using the new lazy reader from [go-lazy](https://github.com/spatialcurrent/go-lazy), which delays opening files until they are ready to be read.